### PR TITLE
bug: explicitly add grpc-context, used by google calendar API, but wa…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-context</artifactId>
+      <version>1.53.0</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>


### PR DESCRIPTION
…s included indirectly by springboot. v1.53.0 includes classes, but in v1.6 they're moved to grpc-api. When spring updates to use newer versions, should be unnecessary to have this dependency added directly.